### PR TITLE
Javadoc comments in BodyAnalyzer, ContentAnalyzer, Email, PhishingDet…

### DIFF
--- a/src/com/waldotaylor/phishingdetector/analysis/BodyAnalyzer.java
+++ b/src/com/waldotaylor/phishingdetector/analysis/BodyAnalyzer.java
@@ -1,3 +1,14 @@
+/**
+ *
+ * @author Taylor Waldo, James Bostick, Bennett Marsee, Caitlyn Pillsbury, Caleb Walton
+ * Date: 4/23/2025
+ * Section: CSC-331-002
+ * Purpose: To extract links and potential attachments from the email body and perform initial content analysis to
+ * determine a score based on patterns that may indicate phishing. The result score of this part of the analysis is
+ * combined with the scores of the tests of the other email parts to determine the likelihood of a phishing attempt.
+ *
+ */
+
 package com.waldotaylor.phishingdetector.analysis;
 import com.waldotaylor.phishingdetector.model.Email;
 
@@ -38,6 +49,12 @@ public class BodyAnalyzer extends ThreatDetector {
      */
     private static final Pattern ATTACHMENT_PATTERN =
             Pattern.compile("(?i)(attached|attachment|file|document|pdf|doc|xlsx|zip)\\s+[^\\s.,;:!?]{1,50}");
+
+    /**
+     * This method analyzes the email body based on factors such as certain phrases, URLs, and attachments.
+     * @param email The email to analyze
+     * @return A score that represents the likelihood of a phishing attempt based on this test alone.
+     */
 
     @Override
     public int analyze(Email email) {

--- a/src/com/waldotaylor/phishingdetector/analysis/ContentAnalyzer.java
+++ b/src/com/waldotaylor/phishingdetector/analysis/ContentAnalyzer.java
@@ -1,3 +1,15 @@
+/**
+ *
+ * @author Taylor Waldo, James Bostick, Bennett Marsee, Caitlyn Pillsbury, Caleb Walton
+ * Date: 4/23/2025
+ * Section: CSC-331-002
+ * Purpose: To analyze the content of the email for suspicious language patterns to determine a score based on patterns
+ * that may indicate phishing. The result score of this part of the analysis is combined with the scores of the tests
+ * of the other email parts to determine the likelihood of a phishing attempt.
+ *
+ */
+
+
 package com.waldotaylor.phishingdetector.analysis;
 import com.waldotaylor.phishingdetector.model.Email;
 import com.waldotaylor.phishingdetector.util.ResourceLoader;
@@ -18,9 +30,8 @@ Logic
 7. Accumulates a score based on these factors, with a max of 100
  */
 
-/**
- * Analyzes email content for phishing language patterns
- */
+
+// Analyzes email content for phishing language patterns
 
 public class ContentAnalyzer extends ThreatDetector {
     // Load phishing keywords from resource file
@@ -53,6 +64,13 @@ public class ContentAnalyzer extends ThreatDetector {
             Pattern.compile("(?i)\\b(login|sign\\s*in)\\b"),
             Pattern.compile("(?i)\\b(verify your)\\b")
     );
+
+    /**
+     * This method analyzes the likelihood of a phishing attempt based on things such as the subject and body's
+     * keywords and writing style.
+     * @param email The email to analyze
+     * @return A score that represents the likelihood of a phishing attempt based on this test alone.
+     */
 
     @Override
     public int analyze(Email email) {

--- a/src/com/waldotaylor/phishingdetector/analysis/SenderAnalyzer.java
+++ b/src/com/waldotaylor/phishingdetector/analysis/SenderAnalyzer.java
@@ -1,4 +1,13 @@
-
+/**
+ *
+ * @author Taylor Waldo, James Bostick, Bennett Marsee, Caitlyn Pillsbury, Caleb Walton
+ * Date: 4/23/2025
+ * Section: CSC-331-002
+ * Purpose: To evaluate how suspicious the sender's email address is based on patterns that may indicate phishing. The
+ * result score of this part of the analysis is combined with the scores of the tests of the other email parts to
+ * determine the likelihood of a phishing attempt.
+ *
+ */
 
 
 package com.waldotaylor.phishingdetector.analysis;
@@ -57,6 +66,14 @@ public class SenderAnalyzer extends ThreatDetector {
          */
     private static final Pattern EMAIL_PATTERN =
             Pattern.compile("^[A-Za-z0-9+_.-]+@(.+)$");
+
+    /**
+     * This method analyzes the email address of the sender for a number of things, such as
+     * the wording and domain of the email address.
+     * @param email The email to analyze
+     * @return A score that represents the likelihood of the email being a phishing attempt based on the sender's email
+     * address alone.
+     */
 
     @Override
     public int analyze(Email email) {

--- a/src/com/waldotaylor/phishingdetector/main/PhishingDetector.java
+++ b/src/com/waldotaylor/phishingdetector/main/PhishingDetector.java
@@ -1,3 +1,12 @@
+/**
+ *
+ * @author Taylor Waldo, James Bostick, Bennett Marsee, Caitlyn Pillsbury, Caleb Walton
+ * Date: 4/23/2025
+ * Section: CSC-331-002
+ * Purpose: To coordinate all the analyzers and process their scores to determine the final phishing score.
+ *
+ */
+
 package com.waldotaylor.phishingdetector.main;
 
 import com.waldotaylor.phishingdetector.analysis.*;

--- a/src/com/waldotaylor/phishingdetector/model/Email.java
+++ b/src/com/waldotaylor/phishingdetector/model/Email.java
@@ -1,3 +1,13 @@
+/**
+ *
+ * @author Taylor Waldo, James Bostick, Bennett Marsee, Caitlyn Pillsbury, Caleb Walton
+ * Date: 4/23/2025
+ * Section: CSC-331-002
+ * Purpose: To define the parts of the email that need to be analyzed and their associated methods. This class
+ * serves as the foundation of our application.
+ *
+ */
+
 package com.waldotaylor.phishingdetector.model;
 
 import java.util.ArrayList;
@@ -15,10 +25,10 @@ public class Email {
     private List<String> attachments;
 
     /**
-     *
-     * @param sender
-     * @param subject
-     * @param body
+     * This is the constructor of an Email object.
+     * @param sender The domain and email address of the sender to be analyzed
+     * @param subject The subject of the email to be analyzed.
+     * @param body The body of the email to be analyzed.
      */
 
     public Email(String sender, String subject, String body) {
@@ -31,45 +41,61 @@ public class Email {
 
     // Getters and Setters
 
+    /**
+     * The getter for the sender variable
+     * @return The sender of the email object
+     */
     public String getSender() {
         return sender;
     }
 
     /**
-     *
-     * @param sender
+     * The setter for the sender variable
+     * @param sender The new sender of the email object
      */
 
     public void getSender(String sender) {
         this.sender = sender; // Needs the new value as input
     }
 
+    /**
+     * The getter for the subject variable
+     * @return The subject of the email object
+     */
     public String getSubject() {
         return subject;
     }
 
     /**
-     *
-     * @param subject
+     * The setter for the subject variable
+     * @param subject The new subject of the email object
      */
 
     public void setSubject(String subject) {
         this.subject = subject;
     }
 
+    /**
+     * The getter for the body variable
+     * @return The body of the email object
+     */
     public String getBody() {
         return body;
     }
 
     /**
-     *
-     * @param body
+     * The setter for the body variable
+     * @param body The new body of the object
      */
 
     public void setBody(String body) {
         this.body = body;
     }
 
+    /**
+     * The getter for the links variable
+     * @return The links of the email object
+     */
     public List<String> getLinks() {
         return links;
     }
@@ -84,7 +110,7 @@ public class Email {
     }
 
     /**
-     *
+     * The getter for the attachments variable
      * @return The list of attachments found in the email
      */
 
@@ -105,6 +131,11 @@ public class Email {
     Returns a string representation of the Email object
  */
 
+    /**
+     *
+     * @return A string representation of the email object. Result string includes sender address, name of subject,
+     * number of characters in body, number of links, and number of attachments.
+     */
     @Override
     public String toString() {
         return "Email{" +

--- a/src/com/waldotaylor/phishingdetector/util/ResourceLoader.java
+++ b/src/com/waldotaylor/phishingdetector/util/ResourceLoader.java
@@ -1,3 +1,13 @@
+/**
+ *
+ * @author Taylor Waldo, James Bostick, Bennett Marsee, Caitlyn Pillsbury, Caleb Walton
+ * Date: 4/23/2025
+ * Section: CSC-331-002
+ * Purpose: To process the contents of the files in the resources folder for use in helping to determine phishing
+ * scores.
+ */
+
+
 package com.waldotaylor.phishingdetector.util;
 
 import java.io.BufferedReader;
@@ -7,9 +17,9 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Utility class for loading resources from the classpath
- */
+
+// Utility class for loading resources from the classpath
+
 public class ResourceLoader {
 
     /**


### PR DESCRIPTION
…ector, ResourceLoader, and SenderAnalyzer java files. Any comments that help with creating javadoc commments are still in the code. Any javadoc headers before classes that were present before editing have been converted to single line comments.